### PR TITLE
Stage 2

### DIFF
--- a/lib/fizz_buzz.rb
+++ b/lib/fizz_buzz.rb
@@ -8,11 +8,11 @@ module FizzBuzz
     BUZZ_OUTPUT = 'Buzz'
 
     def fizz?(n)
-      n % FIZZ_MULTIPLIER == 0
+      n % FIZZ_MULTIPLIER == 0 || n.to_s.include?(FIZZ_MULTIPLIER.to_s)
     end
 
     def buzz?(n)
-      n % BUZZ_MULTIPLIER == 0
+      n % BUZZ_MULTIPLIER == 0 || n.to_s.include?(BUZZ_MULTIPLIER.to_s)
     end
 
     def convert(n)

--- a/test/fizz_buzz_test.rb
+++ b/test/fizz_buzz_test.rb
@@ -7,24 +7,23 @@ class FizzBuzzTest < Minitest::Test
 
   def test_fizz_matcher_is_true_on_multiples_of_3
     assert FizzBuzz.fizz?(3)
-    assert FizzBuzz.fizz?(6)
+    assert FizzBuzz.fizz?(13)
+    assert FizzBuzz.fizz?(132)
     assert FizzBuzz.fizz?(9)
-    assert FizzBuzz.fizz?(15)
 
     refute FizzBuzz.fizz?(1)
     refute FizzBuzz.fizz?(2)
     refute FizzBuzz.fizz?(5)
-    refute FizzBuzz.fizz?(13)
   end
 
   def test_buzz_matcher_is_true_on_multiples_of_5
     assert FizzBuzz.buzz?(5)
     assert FizzBuzz.buzz?(10)
     assert FizzBuzz.buzz?(15)
+    assert FizzBuzz.buzz?(151)
 
     refute FizzBuzz.buzz?(1)
     refute FizzBuzz.buzz?(3)
-    refute FizzBuzz.buzz?(151)
   end
 
   def test_conversion_of_number_to_fizz
@@ -77,7 +76,7 @@ class FizzBuzzTest < Minitest::Test
       Buzz
       11
       Fizz
-      13
+      Fizz
       14
       FizzBuzz
     ], FizzBuzz.list(1..15)

--- a/test/fizz_buzz_test.rb
+++ b/test/fizz_buzz_test.rb
@@ -85,14 +85,14 @@ class FizzBuzzTest < Minitest::Test
   def test_solution
     assert_equal %w[
       1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz
-      11 Fizz 13 14 FizzBuzz 16 17 Fizz 19 Buzz
-      Fizz 22 23 Fizz Buzz 26 Fizz 28 29 FizzBuzz
-      31 32 Fizz 34 Buzz Fizz 37 38 Fizz Buzz
-      41 Fizz 43 44 FizzBuzz 46 47 Fizz 49 Buzz
-      Fizz 52 53 Fizz Buzz 56 Fizz 58 59 FizzBuzz
+      11 Fizz Fizz 14 FizzBuzz 16 17 Fizz 19 Buzz
+      Fizz 22 Fizz Fizz Buzz 26 Fizz 28 29 FizzBuzz
+      Fizz Fizz Fizz Fizz FizzBuzz Fizz Fizz Fizz Fizz Buzz
+      41 Fizz Fizz 44 FizzBuzz 46 47 Fizz 49 Buzz
+      FizzBuzz Buzz FizzBuzz FizzBuzz Buzz Buzz FizzBuzz Buzz Buzz FizzBuzz
       61 62 Fizz 64 Buzz Fizz 67 68 Fizz Buzz
-      71 Fizz 73 74 FizzBuzz 76 77 Fizz 79 Buzz
-      Fizz 82 83 Fizz Buzz 86 Fizz 88 89 FizzBuzz
+      71 Fizz Fizz 74 FizzBuzz 76 77 Fizz 79 Buzz
+      Fizz 82 Fizz Fizz Buzz 86 Fizz 88 89 FizzBuzz
       91 92 Fizz 94 Buzz Fizz 97 98 Fizz Buzz
     ], FizzBuzz.list(1..100)
   end


### PR DESCRIPTION
No specific requirements were given regarding the behaviour of when `FizzBuzz` should behave but I kept the same behaviour and added another one, for when the number both includes `3` and `5`.

- `15` outputs `FizzBuzz` as requested in the original requirement (because 15 is a multiple of `3` and `5`)
- `53` outputs `FizzBuzz` as well because the number includes `3` and `5`